### PR TITLE
Make various improvements 

### DIFF
--- a/MauiHybridAuth/MauiHybridAuth.Web/Components/Layout/NavMenu.razor
+++ b/MauiHybridAuth/MauiHybridAuth.Web/Components/Layout/NavMenu.razor
@@ -1,4 +1,4 @@
-﻿@implements IDisposable
+@implements IDisposable
 @inject NavigationManager NavigationManager
 
 <div class="top-row ps-3 navbar navbar-dark">
@@ -61,7 +61,7 @@
                         </button>
                     </form>
                 </div>
-             </Authorized>               
+             </Authorized>
         </AuthorizeView>
     </nav>
 </div>

--- a/MauiHybridAuth/MauiHybridAuth.Web/MauiHybridAuth.Web.csproj
+++ b/MauiHybridAuth/MauiHybridAuth.Web/MauiHybridAuth.Web.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.*" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.*" />    
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.*" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\MauiHybridAuth.Shared\MauiHybridAuth.Shared.csproj" />
   </ItemGroup>

--- a/MauiHybridAuth/MauiHybridAuth.Web/Program.cs
+++ b/MauiHybridAuth/MauiHybridAuth.Web/Program.cs
@@ -53,9 +53,6 @@ builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
-//Needed for external clients to log in
-app.MapIdentityApi<ApplicationUser>();
-
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
@@ -86,6 +83,9 @@ app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode()
     .AddAdditionalAssemblies(typeof(MauiHybridAuth.Shared._Imports).Assembly);
 
+// Needed for external clients to log in
+app.MapGroup("/identity").MapIdentityApi<ApplicationUser>();
+// Needed for Identity Blazor components
 app.MapAdditionalIdentityEndpoints();
 
 //Add the weather API endpoint and require authorization

--- a/MauiHybridAuth/MauiHybridAuth.Web/Program.cs
+++ b/MauiHybridAuth/MauiHybridAuth.Web/Program.cs
@@ -1,10 +1,9 @@
 using MauiHybridAuth.Shared.Services;
 using MauiHybridAuth.Web.Components;
-using MauiHybridAuth.Web.Services;
-using MauiHybridAuth.Web.Data;
 using MauiHybridAuth.Web.Components.Account;
-using Microsoft.AspNetCore.Authorization.Policy;
-using Microsoft.AspNetCore.Authorization;
+using MauiHybridAuth.Web.Data;
+using MauiHybridAuth.Web.Services;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -20,6 +19,12 @@ builder.Services.AddSingleton<IFormFactor, FormFactor>();
 builder.Services.AddScoped<IWeatherService, WeatherService>();
 
 // Add Auth services used by the Web app
+builder.Services.AddAuthentication(options =>
+{
+    // Ensure that unauthenticated clients redirect to the login page rather than receive a 401 by default.
+    options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
+});
+
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddScoped<IdentityUserAccessor>();
 builder.Services.AddScoped<IdentityRedirectManager>();
@@ -30,19 +35,8 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
-builder.Services.AddAuthentication(options =>
-{
-    options.DefaultScheme = IdentityConstants.ApplicationScheme;
-    options.DefaultSignInScheme = IdentityConstants.ExternalScheme;
-});
-
-builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
-    .AddEntityFrameworkStores<ApplicationDbContext>()
-    .AddSignInManager()
-    .AddDefaultTokenProviders();
-
 //Needed for external clients to log in
-builder.Services.AddIdentityApiEndpoints<ApplicationUser>()
+builder.Services.AddIdentityApiEndpoints<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
     .AddEntityFrameworkStores<ApplicationDbContext>();
 
 builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSender>();

--- a/MauiHybridAuth/MauiHybridAuth.Web/Program.cs
+++ b/MauiHybridAuth/MauiHybridAuth.Web/Program.cs
@@ -51,9 +51,6 @@ builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSe
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-//Register needed elements for authentication:
-builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, AuthorizationMiddlewareResultHandler>();
-
 var app = builder.Build();
 
 //Needed for external clients to log in

--- a/MauiHybridAuth/MauiHybridAuth.Web/Program.cs
+++ b/MauiHybridAuth/MauiHybridAuth.Web/Program.cs
@@ -35,7 +35,7 @@ builder.Services.AddAuthentication(options =>
     options.DefaultScheme = IdentityConstants.ApplicationScheme;
     options.DefaultSignInScheme = IdentityConstants.ExternalScheme;
 });
- 
+
 builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddSignInManager()
@@ -64,7 +64,7 @@ if (app.Environment.IsDevelopment())
     }
     app.UseMigrationsEndPoint();
     app.UseSwagger();
-    app.UseSwaggerUI();    
+    app.UseSwaggerUI();
 }
 else
 {

--- a/MauiHybridAuth/MauiHybridAuth.Web/Properties/launchSettings.json
+++ b/MauiHybridAuth/MauiHybridAuth.Web/Properties/launchSettings.json
@@ -9,20 +9,20 @@
       }
     },
     "profiles": {
-      "http": {
-        "commandName": "Project",
-        "dotnetRunMessages": true,
-        "launchBrowser": true,
-        "applicationUrl": "http://localhost:5101",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development"
-        }
-      },
       "https": {
         "commandName": "Project",
         "dotnetRunMessages": true,
         "launchBrowser": true,
         "applicationUrl": "https://localhost:7157;http://localhost:5101",
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      },
+      "http": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "applicationUrl": "http://localhost:5101",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }

--- a/MauiHybridAuth/MauiHybridAuth.Web/Services/WeatherService.cs
+++ b/MauiHybridAuth/MauiHybridAuth.Web/Services/WeatherService.cs
@@ -13,7 +13,7 @@ namespace MauiHybridAuth.Web.Services
 
             var startDate = DateOnly.FromDateTime(DateTime.Now);
             var summaries = new[] { "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching" };
-            
+
             forecasts = Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = startDate.AddDays(index),

--- a/MauiHybridAuth/MauiHybridAuth/App.xaml.cs
+++ b/MauiHybridAuth/MauiHybridAuth/App.xaml.cs
@@ -4,7 +4,7 @@
     {
         public App()
         {
-            InitializeComponent();            
+            InitializeComponent();
         }
         protected override Window CreateWindow(IActivationState? activationState)
         {

--- a/MauiHybridAuth/MauiHybridAuth/Components/Layout/NavMenu.razor
+++ b/MauiHybridAuth/MauiHybridAuth/Components/Layout/NavMenu.razor
@@ -44,7 +44,7 @@
                         <span class="bi bi-arrow-bar-left-nav-menu" aria-hidden="true"></span>Log Out
                     </NavLink>
                 </div>
-             </Authorized>               
+             </Authorized>
         </AuthorizeView>
     </nav>
 </div>

--- a/MauiHybridAuth/MauiHybridAuth/Components/Pages/Login.razor
+++ b/MauiHybridAuth/MauiHybridAuth/Components/Pages/Login.razor
@@ -8,7 +8,7 @@
     <DataAnnotationsValidator />
     <ValidationSummary />
     <div class="alert alert-danger" hidden="@loginFailureHidden">
-        @LoginModel.LoginFailureMessage
+        @AuthStateProvider.LoginFailureMessage
     </div>
     <div class="form-group">
         <label>Email</label>

--- a/MauiHybridAuth/MauiHybridAuth/Components/Pages/Login.razor
+++ b/MauiHybridAuth/MauiHybridAuth/Components/Pages/Login.razor
@@ -1,6 +1,6 @@
 ﻿@page "/login"
 @inject NavigationManager Navigation
-@inject ICustomAuthenticationStateProvider AuthStateProvider
+@inject MauiAuthenticationStateProvider AuthStateProvider
 
 <h3>Login to Access Application</h3>
 

--- a/MauiHybridAuth/MauiHybridAuth/Components/Pages/Login.razor
+++ b/MauiHybridAuth/MauiHybridAuth/Components/Pages/Login.razor
@@ -23,17 +23,17 @@
     </div>
 </EditForm>
 
-@code {    
-    
+@code {
+
     private LoginModel LoginModel { get; set; } = new();
     private bool loginFailureHidden = true;
 
-    protected override void OnInitialized()    {
-
+    protected override void OnInitialized()
+    {
         if (AuthStateProvider.LoginStatus == LoginStatus.Failed)
-        {            
+        {
             loginFailureHidden = false;
-        }        
+        }
     }
 
     private async Task LoginUser()
@@ -44,8 +44,8 @@
         {
             loginFailureHidden = false;
             return;
-        }        
-        
+        }
+
         Navigation.NavigateTo(""); //Root URL
     }
 }

--- a/MauiHybridAuth/MauiHybridAuth/Components/Pages/Login.razor
+++ b/MauiHybridAuth/MauiHybridAuth/Components/Pages/Login.razor
@@ -25,7 +25,7 @@
 
 @code {
 
-    private LoginModel LoginModel { get; set; } = new();
+    private LoginRequest LoginModel { get; set; } = new();
     private bool loginFailureHidden = true;
 
     protected override void OnInitialized()

--- a/MauiHybridAuth/MauiHybridAuth/Components/Pages/Logout.razor
+++ b/MauiHybridAuth/MauiHybridAuth/Components/Pages/Logout.razor
@@ -8,5 +8,5 @@
     {
         AuthStateProvider.Logout();
         navigationManager.NavigateTo("/login");
-    }      
+    }
 }

--- a/MauiHybridAuth/MauiHybridAuth/Components/Pages/Logout.razor
+++ b/MauiHybridAuth/MauiHybridAuth/Components/Pages/Logout.razor
@@ -1,6 +1,6 @@
 ﻿@page "/logout"
 @inject NavigationManager navigationManager
-@inject ICustomAuthenticationStateProvider AuthStateProvider
+@inject MauiAuthenticationStateProvider AuthStateProvider
 
 <div class="loader loader-bouncing"><span>Redirecting...</span></div>
 @code{

--- a/MauiHybridAuth/MauiHybridAuth/Components/Routes.razor
+++ b/MauiHybridAuth/MauiHybridAuth/Components/Routes.razor
@@ -11,7 +11,7 @@
             <NotAuthorized>
                 <Login />
             </NotAuthorized>
-        </AuthorizeRouteView>   
+        </AuthorizeRouteView>
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
 </Router>

--- a/MauiHybridAuth/MauiHybridAuth/Components/_Imports.razor
+++ b/MauiHybridAuth/MauiHybridAuth/Components/_Imports.razor
@@ -1,4 +1,4 @@
-﻿@using System.Net.Http
+@using System.Net.Http
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
@@ -8,8 +8,8 @@
 @using Microsoft.JSInterop
 @using MauiHybridAuth
 @using MauiHybridAuth.Components
-@using MauiHybridAuth.Components.Pages  
-@using MauiHybridAuth.Components.Layout  
+@using MauiHybridAuth.Components.Pages
+@using MauiHybridAuth.Components.Layout
 @using MauiHybridAuth.Shared
 @using MauiHybridAuth.Services
 @using MauiHybridAuth.Models

--- a/MauiHybridAuth/MauiHybridAuth/MauiProgram.cs
+++ b/MauiHybridAuth/MauiHybridAuth/MauiProgram.cs
@@ -28,10 +28,10 @@ namespace MauiHybridAuth
             // This is the core functionality
             builder.Services.AddAuthorizationCore();
             // This is our custom provider
-            builder.Services.AddScoped<ICustomAuthenticationStateProvider, MauiAuthenticationStateProvider>();
+            builder.Services.AddScoped<MauiAuthenticationStateProvider, MauiAuthenticationStateProvider>();
             // Use our custom provider when the app needs an AuthenticationStateProvider
             builder.Services.AddScoped<AuthenticationStateProvider>(s
-                => (MauiAuthenticationStateProvider)s.GetRequiredService<ICustomAuthenticationStateProvider>());
+                => (MauiAuthenticationStateProvider)s.GetRequiredService<MauiAuthenticationStateProvider>());
 
             // Add device-specific services used by the MauiHybridAuth.Shared project
             builder.Services.AddSingleton<IFormFactor, FormFactor>();

--- a/MauiHybridAuth/MauiHybridAuth/MauiProgram.cs
+++ b/MauiHybridAuth/MauiHybridAuth/MauiProgram.cs
@@ -1,4 +1,4 @@
-﻿using MauiHybridAuth.Services;
+using MauiHybridAuth.Services;
 using MauiHybridAuth.Shared.Services;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.Logging;
@@ -30,7 +30,7 @@ namespace MauiHybridAuth
             // This is our custom provider
             builder.Services.AddScoped<ICustomAuthenticationStateProvider, MauiAuthenticationStateProvider>();
             // Use our custom provider when the app needs an AuthenticationStateProvider
-            builder.Services.AddScoped<AuthenticationStateProvider>(s 
+            builder.Services.AddScoped<AuthenticationStateProvider>(s
                 => (MauiAuthenticationStateProvider)s.GetRequiredService<ICustomAuthenticationStateProvider>());
 
             // Add device-specific services used by the MauiHybridAuth.Shared project

--- a/MauiHybridAuth/MauiHybridAuth/Models/AccessTokenInfo.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Models/AccessTokenInfo.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MauiHybridAuth.Models
+{
+    /// <summary>
+    /// This class represents the information related to an access token.
+    /// </summary>
+    public class AccessTokenInfo
+    {
+        public required string Email { get; set; }
+        public required LoginResponse LoginResponse { get; set; }
+        public required DateTime AccessTokenExpiration { get; set; }
+    }
+}

--- a/MauiHybridAuth/MauiHybridAuth/Models/LoginModel.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Models/LoginModel.cs
@@ -13,8 +13,5 @@ namespace MauiHybridAuth.Models
         [Display(Name = "Password")]
         [DataType(DataType.Password)]
         public string Password { get; set; }
-
-        public string LoginFailureMessage { get; set; } = "Invalid Email or Password. Please try again.";
-        
     }
 }

--- a/MauiHybridAuth/MauiHybridAuth/Models/LoginRequest.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Models/LoginRequest.cs
@@ -2,16 +2,16 @@
 
 namespace MauiHybridAuth.Models
 {
-    public class LoginModel
+    public class LoginRequest
     {
         [Required]
         [Display(Name = "Email Address")]
         [EmailAddress]
-        public string Email { get; set; }
+        public string Email { get; set; } = "";
 
         [Required]
         [Display(Name = "Password")]
         [DataType(DataType.Password)]
-        public string Password { get; set; }
+        public string Password { get; set; } = "";
     }
 }

--- a/MauiHybridAuth/MauiHybridAuth/Models/LoginResponse.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Models/LoginResponse.cs
@@ -3,19 +3,9 @@
 namespace MauiHybridAuth.Models
 {
     /// <summary>
-    /// This class represents the information related to an access token.
-    /// </summary>
-    public class AccessTokenInfo
-    {
-        public required string Email { get; set; }
-        public required LoginToken LoginToken { get; set; }
-        public required DateTime TokenExpiration { get; set; }
-    }
-
-    /// <summary>
     /// This class is used to store the token information received from the server.
     /// </summary>
-    public class LoginToken
+    public class LoginResponse
     {
         [JsonPropertyName("tokenType")]
         public required string TokenType { get; set; }
@@ -29,5 +19,4 @@ namespace MauiHybridAuth.Models
         [JsonPropertyName("refreshToken")]
         public required string RefreshToken { get; set; }
     }
-
 }

--- a/MauiHybridAuth/MauiHybridAuth/Services/HttpClientHelper.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Services/HttpClientHelper.cs
@@ -13,14 +13,14 @@
             {
 #if DEBUG
                 //See: https://learn.microsoft.com/dotnet/maui/data-cloud/local-web-services
-                //Android Emulator uses 10.0.2.2 to refer to localhost            
+                //Android Emulator uses 10.0.2.2 to refer to localhost
                 if (DeviceInfo.Platform == DevicePlatform.Android)
                 {
                     _baseUrl = _baseUrl.Replace("localhost", "10.0.2.2");
                 }
 #endif
                 return _baseUrl;
-            } 
+            }
         }
         public static string LoginUrl => $"{BaseUrl}identity/login";
         public static string RefreshUrl => $"{BaseUrl}identity/refresh";
@@ -28,7 +28,7 @@
 
         public static HttpClient GetHttpClient()
         {
-#if WINDOWS || MACCATALYST 
+#if WINDOWS || MACCATALYST
             return new HttpClient();
 #else
             return new HttpClient(new HttpsClientHandlerService().GetPlatformMessageHandler());

--- a/MauiHybridAuth/MauiHybridAuth/Services/HttpClientHelper.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Services/HttpClientHelper.cs
@@ -22,8 +22,8 @@
                 return _baseUrl;
             } 
         }
-        public static string LoginUrl => $"{BaseUrl}login";
-        public static string RefreshUrl => $"{BaseUrl}refresh";
+        public static string LoginUrl => $"{BaseUrl}identity/login";
+        public static string RefreshUrl => $"{BaseUrl}identity/refresh";
         public static string WeatherUrl => $"{BaseUrl}api/weather";
 
         public static HttpClient GetHttpClient()

--- a/MauiHybridAuth/MauiHybridAuth/Services/LoginStatus.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Services/LoginStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace MauiHybridAuth.Services
+{
+    public enum LoginStatus
+    {
+        None,
+        Success,
+        Failed
+    }
+}

--- a/MauiHybridAuth/MauiHybridAuth/Services/MauiAuthenticationStateProvider.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Services/MauiAuthenticationStateProvider.cs
@@ -6,27 +6,12 @@ using System.Security.Claims;
 
 namespace MauiHybridAuth.Services
 {
-    public enum LoginStatus
-    {
-        None,
-        Success,
-        Failed
-    }
-    public interface ICustomAuthenticationStateProvider
-    {
-        public LoginStatus LoginStatus { get; set; }
-        public string LoginFailureMessage { get; set; }
-        public AccessTokenInfo? AccessTokenInfo { get; }
-        Task<AuthenticationState> GetAuthenticationStateAsync();
-        Task LogInAsync(LoginModel loginModel);
-        void Logout();
-    }
     /// <summary>
     /// This class manages the authentication state of the user.
     /// The class handles user login, logout, and token validation, including refreshing tokens when they are close to expiration.
     /// It uses secure storage to save and retrieve tokens, ensuring that users do not need to log in every time.
     /// </summary>
-    public class MauiAuthenticationStateProvider : AuthenticationStateProvider, ICustomAuthenticationStateProvider
+    public class MauiAuthenticationStateProvider : AuthenticationStateProvider
     {
         //TODO: Place this in AppSettings or Client config file
         private const string AuthenticationType = "Custom authentication";
@@ -192,6 +177,5 @@ namespace MauiHybridAuth.Services
             var identity = new ClaimsIdentity(claims, AuthenticationType);
             return new ClaimsPrincipal(identity);
         }
-
     }
 }

--- a/MauiHybridAuth/MauiHybridAuth/Services/MauiAuthenticationStateProvider.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Services/MauiAuthenticationStateProvider.cs
@@ -22,7 +22,7 @@ namespace MauiHybridAuth.Services
         void Logout();
     }
     /// <summary>
-    /// This class manages the authentication state of the user. 
+    /// This class manages the authentication state of the user.
     /// The class handles user login, logout, and token validation, including refreshing tokens when they are close to expiration.
     /// It uses secure storage to save and retrieve tokens, ensuring that users do not need to log in every time.
     /// </summary>
@@ -34,7 +34,7 @@ namespace MauiHybridAuth.Services
 
         public LoginStatus LoginStatus { get; set; } = LoginStatus.None;
         public string LoginFailureMessage { get; set; } = "";
-        
+
         private ClaimsPrincipal _currentUser = new ClaimsPrincipal(new ClaimsIdentity());
         private AccessTokenInfo? _accessToken;
         public AccessTokenInfo? AccessTokenInfo
@@ -45,8 +45,8 @@ namespace MauiHybridAuth.Services
         public override async Task<AuthenticationState> GetAuthenticationStateAsync()
         {
             //See if the token stored in SecureStorage is still valid and return the authentications state of the user
-            return await CheckTokenAsync();             
-        }  
+            return await CheckTokenAsync();
+        }
 
         public void Logout()
         {
@@ -72,7 +72,7 @@ namespace MauiHybridAuth.Services
                 return new AuthenticationState(_currentUser);
             }
         }
-                       
+
         private async Task<ClaimsPrincipal> LoginWithProviderAsync(LoginModel loginModel)
         {
             ClaimsPrincipal authenticatedUser = new ClaimsPrincipal(new ClaimsIdentity());
@@ -136,22 +136,22 @@ namespace MauiHybridAuth.Services
             {
                 _accessToken = await TokenStorage.GetTokenFromSecureStorageAsync();
 
-                if (_accessToken?.LoginToken != null)                
-                {                    
-                    if (DateTime.UtcNow < _accessToken.TokenExpiration) 
+                if (_accessToken?.LoginToken != null)
+                {
+                    if (DateTime.UtcNow < _accessToken.TokenExpiration)
                     {
                         if (DateTime.UtcNow.AddMinutes(TokenExpirationBuffer) >= _accessToken.TokenExpiration)
-                        { 
+                        {
                             //If the token is close to expiration (within 30 minutes), refresh it automatically
                             await RefreshAccessTokenAsync(_accessToken.LoginToken.RefreshToken, _accessToken.Email);
                         }
-                        
+
                         authenticatedUser = CreateAuthenticatedUser(_accessToken.Email);
                         LoginStatus = LoginStatus.Success;
                     }
                 }
                 if (LoginStatus != LoginStatus.Success)
-                {                   
+                {
                     Logout();
                 }
             }
@@ -183,7 +183,7 @@ namespace MauiHybridAuth.Services
             catch (Exception ex)
             {
                 Debug.WriteLine($"Error refreshing access token: {ex}");
-            }  
+            }
         }
 
         private ClaimsPrincipal CreateAuthenticatedUser(string email)

--- a/MauiHybridAuth/MauiHybridAuth/Services/MauiAuthenticationStateProvider.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Services/MauiAuthenticationStateProvider.cs
@@ -33,10 +33,10 @@ namespace MauiHybridAuth.Services
                 return _currentAuthState;
             }
 
-            var authStateTask = CreateAuthenticationStateFromSecureStorageAsync();
-            NotifyAuthenticationStateChanged(authStateTask);
+            _currentAuthState = CreateAuthenticationStateFromSecureStorageAsync();
+            NotifyAuthenticationStateChanged(_currentAuthState);
 
-            return authStateTask;
+            return _currentAuthState;
         }
 
         public async Task<AccessTokenInfo?> GetAccessTokenInfoAsync()
@@ -46,6 +46,7 @@ namespace MauiHybridAuth.Services
                 return _accessToken;
             }
 
+            Logout();
             return null;
         }
 
@@ -60,10 +61,10 @@ namespace MauiHybridAuth.Services
 
         public Task LogInAsync(LoginRequest loginModel)
         {
-            var loginTask = LogInAsyncCore(loginModel);
-            NotifyAuthenticationStateChanged(loginTask);
+            _currentAuthState = LogInAsyncCore(loginModel);
+            NotifyAuthenticationStateChanged(_currentAuthState);
 
-            return loginTask;
+            return _currentAuthState;
 
             async Task<AuthenticationState> LogInAsyncCore(LoginRequest loginModel)
             {
@@ -120,10 +121,6 @@ namespace MauiHybridAuth.Services
             {
                 authenticatedUser = CreateAuthenticatedUser(_accessToken!.Email);
                 LoginStatus = LoginStatus.Success;
-            }
-            else
-            {
-                Logout();
             }
 
             return new AuthenticationState(authenticatedUser);

--- a/MauiHybridAuth/MauiHybridAuth/Services/TokenStorage.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Services/TokenStorage.cs
@@ -41,16 +41,16 @@ namespace MauiHybridAuth.Services
             {
                 if (!string.IsNullOrEmpty(token) && !string.IsNullOrEmpty(email))
                 {
-                    var loginToken = JsonSerializer.Deserialize<LoginToken>(token);
+                    var loginToken = JsonSerializer.Deserialize<LoginResponse>(token);
                     if (loginToken != null)
                     {
                         DateTime tokenExpiration = DateTime.UtcNow.AddSeconds(loginToken.ExpiresIn);
 
                         accessToken = new AccessTokenInfo
                         {
-                            LoginToken = loginToken,
+                            LoginResponse = loginToken,
                             Email = email,
-                            TokenExpiration = tokenExpiration
+                            AccessTokenExpiration = tokenExpiration
                         };
 
                         await SecureStorage.SetAsync(StorageKeyName, JsonSerializer.Serialize<AccessTokenInfo>(accessToken));

--- a/MauiHybridAuth/MauiHybridAuth/Services/WeatherService.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Services/WeatherService.cs
@@ -33,16 +33,16 @@ namespace MauiHybridAuth.Services
                 }
                 else
                 {
-                    Debug.WriteLine("Token or scheme is null or empty.");                  
+                    Debug.WriteLine("Token or scheme is null or empty.");
                 }
             }
             catch (HttpRequestException httpEx)
             {
-                Debug.WriteLine($"HTTP Request error: {httpEx.Message}");                
+                Debug.WriteLine($"HTTP Request error: {httpEx.Message}");
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"An error occurred: {ex.Message}");                
+                Debug.WriteLine($"An error occurred: {ex.Message}");
             }
             return forecasts;
         }

--- a/MauiHybridAuth/MauiHybridAuth/Services/WeatherService.cs
+++ b/MauiHybridAuth/MauiHybridAuth/Services/WeatherService.cs
@@ -7,9 +7,9 @@ namespace MauiHybridAuth.Services
 {
     public class WeatherService : IWeatherService
     {
-        private readonly ICustomAuthenticationStateProvider _authenticationStateProvider;
+        private readonly MauiAuthenticationStateProvider _authenticationStateProvider;
 
-        public WeatherService(ICustomAuthenticationStateProvider authenticationStateProvider)
+        public WeatherService(MauiAuthenticationStateProvider authenticationStateProvider)
         {
             _authenticationStateProvider = authenticationStateProvider;
         }

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ This sample demonstrates how to build .NET MAUI Blazor Hybrid and Web Apps that 
 ## Running the sample
 1. Clone the repository.
 1. Make sure you have [.NET 9 installed and the MAUI workload](https://learn.microsoft.com/en-us/dotnet/maui/get-started/installation?view=net-maui-9.0&tabs=vswin).
-1. Open the solution in Visual Studio 2022 or VS Code with the .NET MAUI extension installed. 
+1. Open the solution in Visual Studio 2022 or VS Code with the .NET MAUI extension installed.
 1. Set the `MauiHybridAuth` MAUI project as the startup project.
 1. Start the `MauiHybridAuth.Web` project without debugging (in Visual Studio right-click on the project and select "Debug -> Start without Debugging").
 1. Register a user in the Blazor Web app UI or navigate to `https://localhost:7157/swagger` in your browser to pull up the identity endpoints and register a user using the `/Register` endpoint.
@@ -21,8 +21,8 @@ This sample demonstrates how to build .NET MAUI Blazor Hybrid and Web Apps that 
 1. Navigate the web app to `https://localhost:7157/` and the app will behave the same.
 
 ## Tour of the important parts
-### Shared UI 
-The shared UI is in the `MauiHybridAuth.Shared` project. This project contains the Razor components that are shared between the MAUI and Blazor Web projects (Home, Counter and Weather pages). The `Counter.razor` and `Weather.razor` pages are protected by the `[Authorize]` attribute so you cannot navigate to them unless you are logged in. 
+### Shared UI
+The shared UI is in the `MauiHybridAuth.Shared` project. This project contains the Razor components that are shared between the MAUI and Blazor Web projects (Home, Counter and Weather pages). The `Counter.razor` and `Weather.razor` pages are protected by the `[Authorize]` attribute so you cannot navigate to them unless you are logged in.
 
 ```code
 @page "/counter"
@@ -30,7 +30,7 @@ The shared UI is in the `MauiHybridAuth.Shared` project. This project contains t
 @attribute [Authorize]
 ```
 ### Routing in the MAUI & Blazor apps
-The `Routes.razor` uses the `AuthorizeRouteView` to route users appropriately based on their authentication status. If a user is not authenticated, they are redirected to the `Login` page. 
+The `Routes.razor` uses the `AuthorizeRouteView` to route users appropriately based on their authentication status. If a user is not authenticated, they are redirected to the `Login` page.
 
 ```code
 <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)">
@@ -40,7 +40,7 @@ The `Routes.razor` uses the `AuthorizeRouteView` to route users appropriately ba
     <NotAuthorized>
         <Login />
     </NotAuthorized>
-</AuthorizeRouteView>  
+</AuthorizeRouteView>
 ```
 
 The `NavManu.razor` components contain the navigation menu that uses `AuthorizationView` to show/hide links based on the user's authentication status.
@@ -48,15 +48,15 @@ The `NavManu.razor` components contain the navigation menu that uses `Authorizat
 ```code
 <AuthorizeView>
     <NotAuthorized>
-       <!-- Navlinks that display when not logged in -->    
+       <!-- Navlinks that display when not logged in -->
     </NotAuthorized>
     <Authorized>
-        <!-- Navlinks that display when logged in -->    
-    </Authorized>               
+        <!-- Navlinks that display when logged in -->
+    </Authorized>
 </AuthorizeView>
 ```
 ### Setting up the server
-The Blazor Web app contains all the pages and uses the `SignInManager` framework class to manage logins and users. All of this is generated automatically when you create a Blazor Web project and select to use Authentication with Individual accounts. In order for the MAUI client (or any external client) to authenticate, the ASP.NET Identity endpoints need to be exposed. In the `Program.cs` file this is set up with the call to `AddIdentityEnpoints` and `MapIdentityApi`. NOTE: You'll need to remove the generated call to `.AddIdentityCookies` on `.AddAuthentication`. It is not necessary when calling `.AddIdentityEndpoints` and will result in an error. 
+The Blazor Web app contains all the pages and uses the `SignInManager` framework class to manage logins and users. All of this is generated automatically when you create a Blazor Web project and select to use Authentication with Individual accounts. In order for the MAUI client (or any external client) to authenticate, the ASP.NET Identity endpoints need to be exposed. In the `Program.cs` file this is set up with the call to `AddIdentityEnpoints` and `MapIdentityApi`. NOTE: You'll need to remove the generated call to `.AddIdentityCookies` on `.AddAuthentication`. It is not necessary when calling `.AddIdentityEndpoints` and will result in an error.
 
 ```code
 // Add Auth services used by the Web app
@@ -75,7 +75,7 @@ builder.Services.AddAuthentication(options =>
     options.DefaultScheme = IdentityConstants.ApplicationScheme;
     options.DefaultSignInScheme = IdentityConstants.ExternalScheme;
 });
- 
+
 builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddSignInManager()
@@ -109,8 +109,8 @@ private async Task LoginUser()
         //Show error message
         loginFailureHidden = false;
         return;
-    }        
-        
+    }
+
     Navigation.NavigateTo(""); //Root URL
 }
 ```
@@ -120,7 +120,7 @@ NOTE: This sample only implements Login and Logout pages on the MAUI client but 
 The `ICustomAuthenticationStateProvider` interface is implemented by the `MauiAuthenticationStateProvider` class in the `MauiHybridAuth` MAUI project. This class is responsible for managing the user's authentication state and providing the `AuthenticationState` to the app. The `MauiAuthenticationStateProvider` class uses an `HttpClient` to make requests to the server to authenticate the user. See the official documentation for more information on [ASP.NET Core Blazor Hybrid authentication and authorization](https://learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/security/?view=aspnetcore-8.0&pivots=maui).
 
 ```code
-public interface ICustomAuthenticationStateProvider 
+public interface ICustomAuthenticationStateProvider
 {
     public LoginStatus LoginStatus { get; set; }
     public AccessTokenInfo? AccessTokenInfo { get; }
@@ -129,9 +129,9 @@ public interface ICustomAuthenticationStateProvider
     void Logout();
 }
 ```
-The `MauiAuthenticationStateProvider` class uses the `HttpClientHelper` which handles calling localhost via the emulators and simulators for easy testing. See the [official documentation](https://learn.microsoft.com/dotnet/maui/data-cloud/local-web-services) for information on what you need to do to be able to call local services from emulators and simulators. 
+The `MauiAuthenticationStateProvider` class uses the `HttpClientHelper` which handles calling localhost via the emulators and simulators for easy testing. See the [official documentation](https://learn.microsoft.com/dotnet/maui/data-cloud/local-web-services) for information on what you need to do to be able to call local services from emulators and simulators.
 
-It also uses the `TokenStorage` class that uses [`SecureStorage` API](https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/storage/secure-storage?view=net-maui-9.0) to store the user's token securely on the device. It refreshes the token if it's almost expired so the user doesn't have to login every time.  
+It also uses the `TokenStorage` class that uses [`SecureStorage` API](https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/storage/secure-storage?view=net-maui-9.0) to store the user's token securely on the device. It refreshes the token if it's almost expired so the user doesn't have to login every time.
 
 ### MAUI MauiProgram.cs
 The MAUI project's `MauiProgram.cs` file is where the `MauiAuthenticationStateProvider` is registered with the DI container. It also needs to register the Authorization core components where things like `AuthorizeView` are defined.
@@ -142,6 +142,6 @@ builder.Services.AddAuthorizationCore();
 // This is our custom provider
 builder.Services.AddScoped<ICustomAuthenticationStateProvider, MauiAuthenticationStateProvider>();
 // Use our custom provider when the app needs an AuthenticationStateProvider
-builder.Services.AddScoped<AuthenticationStateProvider>(s 
+builder.Services.AddScoped<AuthenticationStateProvider>(s
     => (MauiAuthenticationStateProvider)s.GetRequiredService<ICustomAuthenticationStateProvider>());
 ```


### PR DESCRIPTION
Most if it is non-functional stylistic improvements, but I also fixed the error message when the client fails to log in because the server is down, and fixed the 401 rather than login redirect when you would get upon logout.

The sample now also checks the expiration of the access token each time it's used and refreshes it when necessary. Previously, the access token was only being checked at application start. This can be important if people leave the application open for over an hour which is the default token expiration.